### PR TITLE
ci(go): remove redundant push trigger from Go CI workflow

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -9,14 +9,6 @@ on:
       - "go.sum"
       - ".golangci.yml"
       - ".github/workflows/ci-go.yml"
-  push:
-    branches: [master]
-    paths:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-      - ".golangci.yml"
-      - ".github/workflows/ci-go.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Remove the `push` trigger to `master` from `.github/workflows/ci-go.yml` so Go CI runs only on pull requests.

## Why
The push trigger duplicates CI work after merge and is unnecessary for this workflow.

## Changes
- Deleted the `push` block in `.github/workflows/ci-go.yml`
- Kept existing pull request path filters unchanged

Closes #9