### PR TITLE
Issue #11 docs(standards): add AGENTS bridge and Git standards rules

### DIFF
--- a/.aiassistant/rules/GIT_STANDARDS.md
+++ b/.aiassistant/rules/GIT_STANDARDS.md
@@ -1,0 +1,20 @@
+---
+apply: always
+---
+
+# Git Standards
+
+## Required Workflow
+- Use Git MCP tools for all git operations (branching, committing, rebasing, pushing, PR preparation).
+- Do not use terminal `git` commands unless Git MCP cannot perform the required operation.
+- If terminal `git` is required, explicitly state why before proceeding.
+
+## Commit Message Format
+- Every commit message must start with: `Issue #<issue_number> `.
+- Example: `Issue #9 ci(go): remove push-to-master trigger from Go CI`.
+- This requirement applies to normal commits, fixup commits, and amended commits.
+
+## History Hygiene
+- Keep commits scoped to a single concern when possible.
+- When integrating review fixes, prefer fixup + autosquash into the relevant existing commit.
+- Do not rewrite shared history unless explicitly requested or required for branch hygiene.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+## Repository Rules
+- Mandatory: follow all rules in `.aiassistant/rules/`.
+- Apply all rule files in `.aiassistant/rules/`; if rules conflict, prefer the most specific file for the area being changed.


### PR DESCRIPTION
## Summary
Add repository-level standards documentation for assistant and Git workflows.

## Changes
- Add `AGENTS.md` to require following `.aiassistant/rules/`
- Add explicit git-workflow requirement in `AGENTS.md` for `.aiassistant/rules/GIT_STANDARDS.md`
- Populate `.aiassistant/rules/GIT_STANDARDS.md` with:
  - Git MCP-first workflow
  - terminal git fallback policy
  - commit message prefix requirement: `Issue #<issue_number> ...`
  - commit/history hygiene guidance

Closes #11