### PR TITLE
docs: finalize US-01 and align EPIC-01 scope

### DIFF
--- a/docs/epics/EPIC-01.md
+++ b/docs/epics/EPIC-01.md
@@ -1,0 +1,39 @@
+# EPIC-01: Simple Barn Logging
+
+## Outcome
+Deliver a minimal, reliable online barn logging workflow for core day-to-day records.
+
+## Problem Statement
+Barn operators need a simple way to capture day-to-day records (starting with animals) with a fast, dependable online workflow.
+
+## Scope
+### In Scope
+- Core record capture for barn activity.
+- Online animal record creation and listing through backend APIs and UI.
+- Optional animal photo upload and linkage by `photo_id`.
+- Basic validation for required fields before records are accepted.
+
+### Out of Scope
+- Offline data entry and local persistence.
+- Deferred/offline sync and reconciliation flows.
+- Advanced conflict-resolution UI.
+- Full analytics/reporting dashboards.
+- Bulk import/export workflows.
+- Multi-barn role/permission administration.
+
+## Constraints
+- System requires network connectivity for record operations in this phase.
+
+## Success Criteria
+- A user can create animals through the online workflow.
+- Required field validation prevents invalid animal records from being persisted.
+- Newly created animals are visible in the list after successful save.
+- Optional animal photos can be uploaded and linked during animal creation.
+
+## Linked User Stories
+- `US-01` - Add Animals (`docs/user-stories/US-01.md`)
+- `US-02` - List Animals (`docs/user-stories/US-02.md`)
+- `US-03` - Home Page (`docs/user-stories/US-03.md`)
+
+## Risks and Open Questions
+- Offline-first requirements will need a future epic to introduce local persistence and sync safely.

--- a/docs/user-stories/US-01.md
+++ b/docs/user-stories/US-01.md
@@ -1,0 +1,29 @@
+# US-01: Add Animals
+
+## Epic
+- EPIC-01
+
+## User Story
+As a barn user, I can add a new animal with required details and optional metadata so the animal can be tracked in the system.
+
+## Field Requirements
+- `name` (required)
+- `species` (required: `goat` or `pig`)
+- `customTag` (optional)
+- `birthdate` (optional, `YYYY-MM-DD`)
+- `photo` (optional, uploaded first and linked by `photo_id`)
+
+## Acceptance Criteria
+- [ ] User can create a new animal with `name` and `species`.
+- [ ] `name` is required and cannot be blank.
+- [ ] `species` only accepts `goat` or `pig`.
+- [ ] `customTag` can be omitted.
+- [ ] `birthdate` can be omitted; when provided, it must be a valid `YYYY-MM-DD` date.
+- [ ] `photo` can be omitted; when provided, the flow uploads a file first and links the returned `photo_id` when creating the animal.
+- [ ] Invalid input returns validation errors and does not create an animal.
+- [ ] After successful creation, the animal appears in the animals list.
+
+## Implementation Notes
+- Backend creation API task: `#22`
+- Frontend add-animal flow task: `#29`
+- Photo upload API task: `#30`


### PR DESCRIPTION
## Summary
- finalize `US-01` with explicit field requirements and acceptance criteria
- align `EPIC-01` scope/success criteria with current US-01 direction
- reference active US-01 implementation tasks (`#22`, `#29`, `#30`)

## Files
- `docs/user-stories/US-01.md`
- `docs/epics/EPIC-01.md`