### PR TITLE
Issue #30 feat(api): add photo upload endpoint for US-01

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -48,7 +48,7 @@ func run() error {
 	} else {
 		logger.Info("auto migration disabled")
 	}
-	srv := newHTTPServer(cfg, buildRouter(logger))
+	srv := newHTTPServer(cfg, buildRouter(cfg, logger))
 
 	logger.Info(
 		"http server starting",
@@ -76,13 +76,16 @@ func run() error {
 	return nil
 }
 
-func buildRouter(logger *slog.Logger) http.Handler {
+func buildRouter(cfg config.Config, logger *slog.Logger) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
-	r.Mount("/", httpapi.Routes(logger))
+	r.Mount("/", httpapi.Routes(httpapi.RouteDeps{
+		Logger:        logger,
+		PhotoStoreDir: cfg.PhotoDir,
+	}))
 	return r
 }
 

--- a/backend/internal/adapters/httpapi/handler_set.go
+++ b/backend/internal/adapters/httpapi/handler_set.go
@@ -1,12 +1,26 @@
 // Package httpapi provides HTTP route registration and handlers for backend APIs.
 package httpapi
 
-import "log/slog"
+import (
+	"log/slog"
+)
 
 type handlers struct {
 	logger *slog.Logger
 }
 
+type uploadHandlers struct {
+	logger     *slog.Logger
+	photoStore photoStore
+}
+
 func newHandlers(logger *slog.Logger) handlers {
 	return handlers{logger: logger}
+}
+
+func newUploadHandlers(logger *slog.Logger, photoStore photoStore) uploadHandlers {
+	return uploadHandlers{
+		logger:     logger,
+		photoStore: photoStore,
+	}
 }

--- a/backend/internal/adapters/httpapi/photo_store.go
+++ b/backend/internal/adapters/httpapi/photo_store.go
@@ -1,0 +1,85 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+var errPhotoTooLarge = errors.New("photo too large")
+
+type photoStore interface {
+	Save(ctx context.Context, source io.Reader, maxBytes int64) (photoID string, sizeBytes int64, err error)
+}
+
+type filePhotoStore struct {
+	baseDir string
+}
+
+func newFilePhotoStore(baseDir string) *filePhotoStore {
+	return &filePhotoStore{baseDir: filepath.Clean(baseDir)}
+}
+
+func (s *filePhotoStore) Save(ctx context.Context, source io.Reader, maxBytes int64) (string, int64, error) {
+	if err := os.MkdirAll(s.baseDir, 0o750); err != nil {
+		return "", 0, fmt.Errorf("create photo dir: %w", err)
+	}
+	root, err := os.OpenRoot(s.baseDir)
+	if err != nil {
+		return "", 0, fmt.Errorf("open photo root: %w", err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close photo root: %w", closeErr)
+		}
+	}()
+
+	photoID, err := newPhotoID()
+	if err != nil {
+		return "", 0, err
+	}
+
+	dst, err := root.OpenFile(photoID, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", 0, fmt.Errorf("open destination file: %w", err)
+	}
+
+	success := false
+	defer func() {
+		_ = dst.Close()
+		if !success {
+			_ = root.Remove(photoID)
+		}
+	}()
+
+	limited := &io.LimitedReader{R: source, N: maxBytes + 1}
+	writtenBytes, err := io.Copy(dst, limited)
+	if err != nil {
+		return "", 0, fmt.Errorf("write photo file: %w", err)
+	}
+	if writtenBytes > maxBytes {
+		return "", 0, errPhotoTooLarge
+	}
+
+	select {
+	case <-ctx.Done():
+		return "", 0, ctx.Err()
+	default:
+	}
+
+	success = true
+	return photoID, writtenBytes, nil
+}
+
+func newPhotoID() (string, error) {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return hex.EncodeToString(bytes[:]), nil
+}

--- a/backend/internal/adapters/httpapi/routes.go
+++ b/backend/internal/adapters/httpapi/routes.go
@@ -8,13 +8,21 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// RouteDeps contains dependencies required to build HTTP routes.
+type RouteDeps struct {
+	Logger        *slog.Logger
+	PhotoStoreDir string
+}
+
 // Routes builds the public HTTP router for backend endpoints.
-func Routes(logger *slog.Logger) http.Handler {
+func Routes(deps RouteDeps) http.Handler {
 	r := chi.NewRouter()
-	h := newHandlers(logger)
+	h := newHandlers(deps.Logger)
+	upload := newUploadHandlers(deps.Logger, newFilePhotoStore(deps.PhotoStoreDir))
 
 	r.Get("/healthz", h.healthz)
 	r.Get("/readyz", h.readyz)
+	r.Post("/uploads/photos", upload.uploadPhoto)
 	r.NotFound(h.notFound)
 
 	return r

--- a/backend/internal/adapters/httpapi/routes_test.go
+++ b/backend/internal/adapters/httpapi/routes_test.go
@@ -82,7 +82,10 @@ func TestRoutes(t *testing.T) {
 func performRequest(t *testing.T, method, path string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	h := Routes(testLogger())
+	h := Routes(RouteDeps{
+		Logger:        testLogger(),
+		PhotoStoreDir: t.TempDir(),
+	})
 	req := httptest.NewRequest(method, path, nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/backend/internal/adapters/httpapi/upload_photo.go
+++ b/backend/internal/adapters/httpapi/upload_photo.go
@@ -1,0 +1,112 @@
+package httpapi
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+const (
+	maxPhotoSizeBytes               = 10 << 20 // 10 MiB
+	maxMultipartOverheadBytes       = 1 << 20  // 1 MiB for multipart envelope
+	maxUploadRequestBytes     int64 = maxPhotoSizeBytes + maxMultipartOverheadBytes
+	photoFieldName                  = "photo"
+)
+
+var allowedPhotoContentTypes = map[string]struct{}{
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/webp": {},
+	"image/gif":  {},
+}
+
+func (h uploadHandlers) uploadPhoto(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadRequestBytes)
+
+	if err := r.ParseMultipartForm(maxPhotoSizeBytes + 512); err != nil {
+		if isRequestTooLarge(err) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]any{"error": "photo_too_large"})
+			return
+		}
+
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_multipart"})
+		return
+	}
+
+	if r.MultipartForm != nil {
+		defer func() {
+			if err := r.MultipartForm.RemoveAll(); err != nil {
+				h.logger.Warn("remove multipart temp files", slog.Any("error", err))
+			}
+		}()
+	}
+
+	if h.photoStore == nil {
+		h.logger.Error("photo store is nil")
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	file, _, err := r.FormFile(photoFieldName)
+	if err != nil {
+		if isRequestTooLarge(err) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]any{"error": "photo_too_large"})
+			return
+		}
+
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "photo_required"})
+		return
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			h.logger.Warn("close uploaded file", slog.Any("error", closeErr))
+		}
+	}()
+
+	sniffBuffer := make([]byte, 512)
+	sniffBytesRead, sniffErr := io.ReadFull(file, sniffBuffer)
+	if sniffErr != nil && !errors.Is(sniffErr, io.EOF) && !errors.Is(sniffErr, io.ErrUnexpectedEOF) {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_photo"})
+		return
+	}
+	if sniffBytesRead == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_photo"})
+		return
+	}
+
+	sniffBuffer = sniffBuffer[:sniffBytesRead]
+	contentType := http.DetectContentType(sniffBuffer)
+	if _, ok := allowedPhotoContentTypes[contentType]; !ok {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "unsupported_photo_type"})
+		return
+	}
+
+	photoID, totalBytes, err := h.photoStore.Save(
+		r.Context(),
+		io.MultiReader(bytes.NewReader(sniffBuffer), file),
+		maxPhotoSizeBytes,
+	)
+	if err != nil {
+		if errors.Is(err, errPhotoTooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]any{"error": "photo_too_large"})
+			return
+		}
+
+		h.logger.Error("save photo", slog.Any("error", err))
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal_error"})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"photo_id":     photoID,
+		"content_type": contentType,
+		"size_bytes":   totalBytes,
+	})
+}
+
+func isRequestTooLarge(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}

--- a/backend/internal/adapters/httpapi/upload_photo_test.go
+++ b/backend/internal/adapters/httpapi/upload_photo_test.go
@@ -1,0 +1,150 @@
+package httpapi
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUploadPhoto(t *testing.T) {
+	t.Parallel()
+
+	photoDir := t.TempDir()
+	router := Routes(RouteDeps{
+		Logger:        testLogger(),
+		PhotoStoreDir: photoDir,
+	})
+
+	t.Run("created", func(t *testing.T) {
+		t.Parallel()
+
+		rec := performUpload(t, router, "animal.png", samplePNGBytes())
+		assertJSONStatus(t, rec, http.StatusCreated)
+
+		var payload map[string]any
+		decodeJSON(t, rec, &payload)
+
+		photoID, ok := payload["photo_id"].(string)
+		if !ok || photoID == "" {
+			t.Fatalf("expected non-empty photo_id, got %#v", payload["photo_id"])
+		}
+
+		contentType, ok := payload["content_type"].(string)
+		if !ok || contentType == "" {
+			t.Fatalf("expected non-empty content_type, got %#v", payload["content_type"])
+		}
+
+		if got := payload["size_bytes"]; got == nil {
+			t.Fatalf("expected size_bytes, got nil")
+		}
+
+		if _, err := os.Stat(filepath.Join(photoDir, photoID)); err != nil {
+			t.Fatalf("expected saved photo file: %v", err)
+		}
+	})
+
+	t.Run("photo required", func(t *testing.T) {
+		t.Parallel()
+
+		rec := performUploadWithoutPhoto(t, router)
+		assertJSONStatus(t, rec, http.StatusBadRequest)
+
+		var payload map[string]any
+		decodeJSON(t, rec, &payload)
+		if payload["error"] != "photo_required" {
+			t.Fatalf("expected error=photo_required, got %#v", payload["error"])
+		}
+	})
+
+	t.Run("non-image file is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		rec := performUpload(t, router, "animal.txt", []byte("not-an-image"))
+		assertJSONStatus(t, rec, http.StatusBadRequest)
+
+		var payload map[string]any
+		decodeJSON(t, rec, &payload)
+		if payload["error"] != "unsupported_photo_type" {
+			t.Fatalf("expected error=unsupported_photo_type, got %#v", payload["error"])
+		}
+	})
+
+	t.Run("request body too large is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		oversized := append(samplePNGBytes(), bytes.Repeat([]byte{0x00}, int(maxUploadRequestBytes)+1)...)
+		rec := performUpload(t, router, "huge.png", oversized)
+		assertJSONStatus(t, rec, http.StatusRequestEntityTooLarge)
+
+		var payload map[string]any
+		decodeJSON(t, rec, &payload)
+		if payload["error"] != "photo_too_large" {
+			t.Fatalf("expected error=photo_too_large, got %#v", payload["error"])
+		}
+	})
+}
+
+func performUpload(t *testing.T, router http.Handler, filename string, content []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, contentType := buildMultipartBody(t, filename, content)
+	req := httptest.NewRequest(http.MethodPost, "/uploads/photos", body)
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func performUploadWithoutPhoto(t *testing.T, router http.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/uploads/photos", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func buildMultipartBody(t *testing.T, filename string, content []byte) (*bytes.Buffer, string) {
+	t.Helper()
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile(photoFieldName, filename)
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := io.Copy(part, bytes.NewReader(content)); err != nil {
+		t.Fatalf("write form file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	return body, writer.FormDataContentType()
+}
+
+func samplePNGBytes() []byte {
+	return []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+		0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41,
+		0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+		0x00, 0x03, 0x01, 0x01, 0x00, 0x18, 0xDD, 0x8D,
+		0x18, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+		0x44, 0xAE, 0x42, 0x60, 0x82,
+	}
+}

--- a/backend/internal/infrastructure/config/config.go
+++ b/backend/internal/infrastructure/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	HTTPAddr        string
 	DBPath          string
 	MigrationsPath  string
+	PhotoDir        string
 	AutoMigrate     bool
 	LogLevel        slog.Level
 	ShutdownTimeout time.Duration
@@ -28,6 +29,7 @@ func LoadFromEnv() (Config, error) {
 		HTTPAddr:        getenv("BARNLOG_HTTP_ADDR", ":8080"),
 		DBPath:          getenv("BARNLOG_DB_PATH", "backend/db/dev.sqlite3"),
 		MigrationsPath:  getenv("BARNLOG_MIGRATIONS_PATH", "backend/db/migrations"),
+		PhotoDir:        getenv("BARNLOG_PHOTO_DIR", "backend/uploads/photos"),
 		AutoMigrate:     true,
 		ShutdownTimeout: 10 * time.Second,
 	}

--- a/backend/internal/infrastructure/config/config_test.go
+++ b/backend/internal/infrastructure/config/config_test.go
@@ -12,6 +12,7 @@ func TestLoadFromEnvDefaults(t *testing.T) {
 	t.Setenv("BARNLOG_HTTP_ADDR", "")
 	t.Setenv("BARNLOG_DB_PATH", "")
 	t.Setenv("BARNLOG_MIGRATIONS_PATH", "")
+	t.Setenv("BARNLOG_PHOTO_DIR", "")
 	t.Setenv("BARNLOG_AUTO_MIGRATE", "")
 	t.Setenv("BARNLOG_LOG_LEVEL", "")
 	t.Setenv("BARNLOG_SHUTDOWN_TIMEOUT", "")
@@ -33,6 +34,9 @@ func TestLoadFromEnvDefaults(t *testing.T) {
 	if cfg.MigrationsPath != "backend/db/migrations" {
 		t.Fatalf("expected MigrationsPath=backend/db/migrations, got %q", cfg.MigrationsPath)
 	}
+	if cfg.PhotoDir != "backend/uploads/photos" {
+		t.Fatalf("expected PhotoDir=backend/uploads/photos, got %q", cfg.PhotoDir)
+	}
 	if !cfg.AutoMigrate {
 		t.Fatalf("expected AutoMigrate=true by default")
 	}
@@ -49,6 +53,7 @@ func TestLoadFromEnvCustomValues(t *testing.T) {
 	t.Setenv("BARNLOG_HTTP_ADDR", ":9090")
 	t.Setenv("BARNLOG_DB_PATH", "backend/db/custom.sqlite3")
 	t.Setenv("BARNLOG_MIGRATIONS_PATH", "backend/db/custom-migrations")
+	t.Setenv("BARNLOG_PHOTO_DIR", "backend/uploads/custom-photos")
 	t.Setenv("BARNLOG_AUTO_MIGRATE", "false")
 	t.Setenv("BARNLOG_LOG_LEVEL", "debug")
 	t.Setenv("BARNLOG_SHUTDOWN_TIMEOUT", "3s")
@@ -69,6 +74,9 @@ func TestLoadFromEnvCustomValues(t *testing.T) {
 	}
 	if cfg.MigrationsPath != "backend/db/custom-migrations" {
 		t.Fatalf("expected MigrationsPath=backend/db/custom-migrations, got %q", cfg.MigrationsPath)
+	}
+	if cfg.PhotoDir != "backend/uploads/custom-photos" {
+		t.Fatalf("expected PhotoDir=backend/uploads/custom-photos, got %q", cfg.PhotoDir)
 	}
 	if cfg.AutoMigrate {
 		t.Fatalf("expected AutoMigrate=false, got true")


### PR DESCRIPTION
## Summary
- add `POST /uploads/photos` endpoint for US-01 photo uploads
- store uploaded bytes in filesystem-backed photo store and return `photo_id`
- add route dependency wiring and config via `BARNLOG_PHOTO_DIR`
- add/extend handler and config tests for upload flow

## Linked Issue
- Closes #30

## Quality Gates
- `golangci-lint run --timeout=5m ./backend/cmd/server ./backend/internal/...` (0 issues)
- `go vet -waitgroup -hostport ./...` (clean)
- `go test ./...` from `backend/` (pass)

## Scope Notes
- PR intentionally includes only backend files for task #30.
- Unrelated local changes (rules/docs/skills) were not included.