### PR TITLE
Issue #21 docs(us-01): update species options and tag field

### DIFF
--- a/docs/user-stories/US-01.md
+++ b/docs/user-stories/US-01.md
@@ -8,16 +8,16 @@ As a barn user, I can add a new animal with required details and optional metada
 
 ## Field Requirements
 - `name` (required)
-- `species` (required: `goat` or `pig`)
-- `customTag` (optional)
+- `species` (required: `goat`, `pig`, `dog`, `cat`)
+- `tag` (optional)
 - `birthdate` (optional, `YYYY-MM-DD`)
 - `photo` (optional, uploaded first and linked by `photo_id`)
 
 ## Acceptance Criteria
 - [ ] User can create a new animal with `name` and `species`.
 - [ ] `name` is required and cannot be blank.
-- [ ] `species` only accepts `goat` or `pig`.
-- [ ] `customTag` can be omitted.
+- [ ] `species` only accepts `goat`, `pig`, `dog`, `cat`.
+- [ ] `tag` can be omitted.
 - [ ] `birthdate` can be omitted; when provided, it must be a valid `YYYY-MM-DD` date.
 - [ ] `photo` can be omitted; when provided, the flow uploads a file first and links the returned `photo_id` when creating the animal.
 - [ ] Invalid input returns validation errors and does not create an animal.


### PR DESCRIPTION
## Summary
- update `US-01` species options to: `goat`, `pig`, `dog`, `cat`
- rename optional field from `customTag` to `tag`
- align acceptance criteria text with updated field naming and allowed values

## Linked Story
- refs #21

## Files
- `docs/user-stories/US-01.md`

## Notes
- This PR intentionally includes only the `US-01` doc update.