### PR TITLE
Issue #30 docs(standards): add explicit HTTP handler rule

### DIFF
--- a/.aiassistant/rules/GO_STANDARDS.md
+++ b/.aiassistant/rules/GO_STANDARDS.md
@@ -79,6 +79,15 @@ Use when logic becomes non-trivial.
 Public: HTTP + OpenAPI  
 Internal: package boundaries and clear interfaces (no gRPC by default in this monolith)
 
+### HTTP Handler Rule
+
+Handlers are transport adapters and must stay thin.
+
+- Parse and validate transport input (headers/path/query/body).
+- Call application/domain services for business logic.
+- Map service/domain errors to HTTP status + response payload.
+- Do not embed business rules, orchestration-heavy flows, or persistence logic directly in handlers.
+
 ---
 
 ## 🔐 Authentication


### PR DESCRIPTION
## Summary
- add an explicit `HTTP Handler Rule` section to `GO_STANDARDS.md`
- define thin-handler responsibilities for transport parsing, service delegation, and HTTP error mapping
- explicitly forbid business/persistence/orchestration logic in handlers

## Files
- `.aiassistant/rules/GO_STANDARDS.md`

## Notes
- PR is intentionally scoped to standards documentation only.