### PR TITLE
[TASK] Pin frontend package manager to Bun

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,5 +54,5 @@
     "vitest": "^4.0.18",
     "vitest-browser-svelte": "^2.0.2"
   },
-  "packageManager": "bun@1.3.3"
+  "packageManager": "bun@1.3.10"
 }


### PR DESCRIPTION
## Summary
- add "packageManager": "bun@1.3.10" to frontend/package.json to pin Bun version for contributors and CI

## Validation
- bun run --cwd frontend check

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling metadata to specify the frontend package manager as bun@1.3.10.
  * No changes to runtime behavior, public APIs, or exported entities—no user-facing functionality was altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->