### PR TITLE
test(e2e): add dual mocked/full-stack Playwright setup (#106)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -52,3 +52,35 @@ jobs:
 
       - name: Unit tests
         run: bunx vitest --project unit --run
+
+  frontend-fullstack-e2e:
+    name: Frontend Fullstack E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Fullstack E2E tests
+        run: bun run test:e2e:fullstack

--- a/frontend/e2e/demo.fullstack.spec.ts
+++ b/frontend/e2e/demo.fullstack.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test";
 
 test("fullstack: backend health and frontend home are reachable", async ({ page, request }) => {
-  const backendHealth = await request.get("http://127.0.0.1:8081/healthz");
+  const backendURL = process.env.PLAYWRIGHT_BACKEND_URL ?? "http://127.0.0.1:8081";
+  const backendHealth = await request.get(`${backendURL}/healthz`);
   expect(backendHealth.ok()).toBe(true);
 
   await page.goto("/");

--- a/frontend/e2e/demo.fullstack.spec.ts
+++ b/frontend/e2e/demo.fullstack.spec.ts
@@ -1,9 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("fullstack: backend health and frontend home are reachable", async ({
-  page,
-  request,
-}) => {
+test("fullstack: backend health and frontend home are reachable", async ({ page, request }) => {
   const backendHealth = await request.get("http://127.0.0.1:8081/healthz");
   expect(backendHealth.ok()).toBe(true);
 

--- a/frontend/e2e/demo.fullstack.spec.ts
+++ b/frontend/e2e/demo.fullstack.spec.ts
@@ -4,7 +4,7 @@ test("fullstack: backend health and frontend home are reachable", async ({
   page,
   request,
 }) => {
-  const backendHealth = await request.get("http://localhost:8081/healthz");
+  const backendHealth = await request.get("http://127.0.0.1:8081/healthz");
   expect(backendHealth.ok()).toBe(true);
 
   await page.goto("/");

--- a/frontend/e2e/demo.fullstack.spec.ts
+++ b/frontend/e2e/demo.fullstack.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+
+test("fullstack: backend health and frontend home are reachable", async ({
+  page,
+  request,
+}) => {
+  const backendHealth = await request.get("http://localhost:8081/healthz");
+  expect(backendHealth.ok()).toBe(true);
+
+  await page.goto("/");
+  await expect(page.locator("h1")).toBeVisible();
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "check:api-types": "bun run gen:api-types && git diff --exit-code -- src/lib/api/generated/types.ts",
     "test:unit": "vitest",
     "test": "bun run test:unit -- --run && bun run test:e2e",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:fullstack": "playwright test -c playwright.fullstack.config.ts"
   },
   "dependencies": {
     "@internationalized/date": "^3.12.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "gen:api-types": "openapi-typescript ../backend/openapi/openapi.yaml -o src/lib/api/generated/types.ts",
     "check:api-types": "bun run gen:api-types && git diff --exit-code -- src/lib/api/generated/types.ts",
     "test:unit": "vitest",
-    "test": "bun run test:unit -- --run && bun run test:e2e",
+    "test": "bun run test:unit -- --run && bun run test:e2e && bun run test:e2e:fullstack",
     "test:e2e": "playwright test",
     "test:e2e:fullstack": "playwright test -c playwright.fullstack.config.ts"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   webServer: {
-    command: "bun run build && bun run preview -- --strictPort --port 4173",
-    url: "http://127.0.0.1:4173",
+    command: "bun run build && bun run preview -- --host localhost --strictPort --port 4173",
+    url: "http://localhost:4173",
     reuseExistingServer: !process.env.CI,
   },
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: "http://localhost:4173",
   },
   testDir: "e2e",
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
+  testIgnore: "**/*.fullstack.spec.ts",
   webServer: {
     command: "bun run build && bun run preview -- --host localhost --strictPort --port 4173",
     url: "http://localhost:4173",

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "@playwright/test";
 
 const backendURL = "http://127.0.0.1:8081";
 const frontendURL = "http://localhost:4173";
+const runID =
+  process.env.GITHUB_RUN_ID ??
+  `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tempRoot = process.env.RUNNER_TEMP ?? "/tmp";
+const dbPath = `${tempRoot}/barnlog-e2e-${runID}.sqlite3`;
+const fileDir = `${tempRoot}/barnlog-e2e-files-${runID}`;
 
 export default defineConfig({
   testDir: "e2e",
@@ -12,19 +18,19 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: "go run ./backend/cmd/server",
+      command: `rm -rf "${dbPath}" "${fileDir}" && go run ./backend/cmd/server`,
       cwd: "..",
       env: {
         ...process.env,
         BARNLOG_AUTO_MIGRATE: "true",
-        BARNLOG_DB_PATH: "/tmp/barnlog-e2e.sqlite3",
+        BARNLOG_DB_PATH: dbPath,
         BARNLOG_ENV: "test",
-        BARNLOG_FILE_DIR: "/tmp/barnlog-e2e-files",
+        BARNLOG_FILE_DIR: fileDir,
         BARNLOG_HTTP_ADDR: "127.0.0.1:8081",
         BARNLOG_LOG_LEVEL: "error",
       },
       name: "Backend",
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 120_000,
       url: `${backendURL}/healthz`,
     },
@@ -36,7 +42,7 @@ export default defineConfig({
         PUBLIC_API_BASE_URL: backendURL,
       },
       name: "Frontend",
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 120_000,
       url: frontendURL,
     },

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { defineConfig } from "@playwright/test";
 
-const backendURL = "http://localhost:8081";
+const backendURL = "http://127.0.0.1:8081";
 const frontendURL = "http://localhost:4173";
 
 export default defineConfig({

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -11,6 +11,7 @@ const runID =
 const tempRoot = process.env.RUNNER_TEMP ?? "/tmp";
 const dbPath = `${tempRoot}/barnlog-e2e-${runID}.sqlite3`;
 const fileDir = `${tempRoot}/barnlog-e2e-files-${runID}`;
+process.env.PLAYWRIGHT_BACKEND_URL = backendURL;
 
 export default defineConfig({
   testDir: "e2e",

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -3,9 +3,11 @@ import { defineConfig } from "@playwright/test";
 
 const backendURL = "http://127.0.0.1:8081";
 const frontendURL = "http://localhost:4173";
+const randomBase = 16;
+const randomSliceStart = 2;
 const runID =
   process.env.GITHUB_RUN_ID ??
-  `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  `${Date.now()}-${Math.random().toString(randomBase).slice(randomSliceStart)}`;
 const tempRoot = process.env.RUNNER_TEMP ?? "/tmp";
 const dbPath = `${tempRoot}/barnlog-e2e-${runID}.sqlite3`;
 const fileDir = `${tempRoot}/barnlog-e2e-files-${runID}`;

--- a/frontend/playwright.fullstack.config.ts
+++ b/frontend/playwright.fullstack.config.ts
@@ -1,0 +1,44 @@
+/// <reference types="node" />
+import { defineConfig } from "@playwright/test";
+
+const backendURL = "http://localhost:8081";
+const frontendURL = "http://localhost:4173";
+
+export default defineConfig({
+  testDir: "e2e",
+  testMatch: "**/*.fullstack.spec.ts",
+  use: {
+    baseURL: frontendURL,
+  },
+  webServer: [
+    {
+      command: "go run ./backend/cmd/server",
+      cwd: "..",
+      env: {
+        ...process.env,
+        BARNLOG_AUTO_MIGRATE: "true",
+        BARNLOG_DB_PATH: "/tmp/barnlog-e2e.sqlite3",
+        BARNLOG_ENV: "test",
+        BARNLOG_FILE_DIR: "/tmp/barnlog-e2e-files",
+        BARNLOG_HTTP_ADDR: "127.0.0.1:8081",
+        BARNLOG_LOG_LEVEL: "error",
+      },
+      name: "Backend",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      url: `${backendURL}/healthz`,
+    },
+    {
+      command: "bun run build && bun run preview -- --host localhost --strictPort --port 4173",
+      cwd: ".",
+      env: {
+        ...process.env,
+        PUBLIC_API_BASE_URL: backendURL,
+      },
+      name: "Frontend",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      url: frontendURL,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add dedicated full-stack Playwright config that boots backend + frontend
- keep default mocked/frontend-focused Playwright config for fast runs
- add full-stack demo spec that validates backend health and frontend availability
- add `test:e2e:fullstack` script

## Issue
- Closes #106

## Validation
- `bun run test:e2e:fullstack -- e2e/demo.fullstack.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating the complete application stack, including backend service health checks and frontend home page functionality.
  * Introduced dedicated test configuration and npm script for running integrated fullstack tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->