### PR TITLE
Fix CodeRabbit path filters to include app code reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,8 @@
 reviews:
   path_filters:
-    - "!/.agents/skills/**"
+    - "/frontend/**"
+    - "/backend/**"
+    - "/scripts/**"
     - "/.agents/skills/barnboard/**"
-    - "/.agents/skills/barnreview/**"
+    - "!/.agents/skills/**"
     - "!/skills-lock.json"


### PR DESCRIPTION
## Summary
- include frontend/**, backend/**, and scripts/** in CodeRabbit path filters
- keep vendored skills excluded by default
- explicitly include /.agents/skills/barnboard/**
- keep skills-lock.json excluded

## Why
CodeRabbit was skipping app files as included by none because path filters did not explicitly include normal source paths.

Closes #110