### PR TITLE
Fix CodeRabbit path_filters glob patterns (remove leading slashes)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,8 @@
 reviews:
   path_filters:
-    - "!/.agents/skills/**"
+    - "/frontend/**"
+    - "/backend/**"
+    - "/scripts/**"
     - "/.agents/skills/barnboard/**"
-    - "/.agents/skills/barnreview/**"
+    - "!/.agents/skills/**"
     - "!/skills-lock.json"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,8 @@
 reviews:
   path_filters:
-    - "/frontend/**"
-    - "/backend/**"
-    - "/scripts/**"
-    - "/.agents/skills/barnboard/**"
-    - "!/.agents/skills/**"
-    - "!/skills-lock.json"
+    - "frontend/**"
+    - "backend/**"
+    - "scripts/**"
+    - ".agents/skills/barnboard/**"
+    - "!.agents/skills/**"
+    - "!skills-lock.json"


### PR DESCRIPTION
## Summary
- switch path_filters to relative globs without leading slashes
- keep targeted includes for frontend, backend, scripts, and barnboard skill path
- keep exclusions for vendored skills and skills-lock.json

## Why
CodeRabbit was reporting frontend files as included by none. Leading-slash patterns were not matching as intended.

Refs #110