### PR TITLE
ci(codecov): always comment on PR coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,4 +18,4 @@ coverage:
 
 comment:
   layout: "reach,diff,flags,files"
-  require_changes: true
+  require_changes: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,15 +6,21 @@ coverage:
           - backend
         target: auto
         threshold: 1%
+        informational: true
       frontend:
         flags:
           - frontend
         target: auto
         threshold: 1%
+        informational: true
     patch:
       default:
         target: auto
         threshold: 1%
+        informational: true
+
+github_checks:
+  annotations: true
 
 comment:
   layout: "reach,diff,flags,files"


### PR DESCRIPTION
## Summary
- set `comment.require_changes` to `false` in `codecov.yml`
- make Codecov post PR comments even when coverage delta is unchanged

## Linked Issues
- closes #113
- relates to #104